### PR TITLE
Fixing bug if no option is clicked first round

### DIFF
--- a/script.js
+++ b/script.js
@@ -107,6 +107,7 @@ ghibliApp.gameSetup = function(apiData) {
     // Display movie titles as options
     const choiceElement = document.querySelectorAll('.choice');
     const labelElement = document.querySelectorAll('.label');
+    choiceElement[0].checked = true;
     choiceElement.forEach(choice => {
         for(let i = 0; i < labelElement.length; i++) {
             choiceElement[i].value = apiData[i].title;


### PR DESCRIPTION
I realized there was a rare bug that if no option was clicked on first open and the next button was clicked, the buttons all disappeared
I checked the first answer as default to fix this! 
`choiceElement[0].checked = true;`